### PR TITLE
🗄️ Add SQLite storage layer

### DIFF
--- a/mailview/store.py
+++ b/mailview/store.py
@@ -1,0 +1,286 @@
+"""SQLite storage layer for captured emails."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import aiosqlite
+
+if TYPE_CHECKING:
+    from mailview.models import Attachment, Email
+
+
+DEFAULT_DB_PATH = "/tmp/mailview/mailview.db"  # nosec B108 - intentional for dev tool
+
+
+class EmailStore:
+    """Async SQLite store for captured emails."""
+
+    def __init__(self, db_path: str = DEFAULT_DB_PATH) -> None:
+        """Initialize store with database path.
+
+        Args:
+            db_path: Path to SQLite database file
+        """
+        self.db_path = db_path
+        self._initialized = False
+
+    async def _ensure_initialized(self) -> None:
+        """Create database and tables if they don't exist."""
+        if self._initialized:
+            return
+
+        # Create directory if needed
+        db_dir = Path(self.db_path).parent
+        db_dir.mkdir(parents=True, exist_ok=True)
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS emails (
+                    id TEXT PRIMARY KEY,
+                    sender TEXT,
+                    recipients_to TEXT,
+                    recipients_cc TEXT,
+                    recipients_bcc TEXT,
+                    subject TEXT,
+                    html_body TEXT,
+                    text_body TEXT,
+                    headers TEXT,
+                    created_at TEXT
+                )
+            """)
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS attachments (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    email_id TEXT,
+                    filename TEXT,
+                    content_type TEXT,
+                    size INTEGER,
+                    content BLOB,
+                    FOREIGN KEY (email_id) REFERENCES emails(id) ON DELETE CASCADE
+                )
+            """)
+            await db.execute("""
+                CREATE INDEX IF NOT EXISTS idx_attachments_email_id
+                ON attachments(email_id)
+            """)
+            await db.commit()
+
+        self._initialized = True
+
+    async def save(self, email: Email) -> None:
+        """Save an email to the store.
+
+        Args:
+            email: Email to save
+        """
+        await self._ensure_initialized()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """
+                INSERT OR REPLACE INTO emails
+                (id, sender, recipients_to, recipients_cc, recipients_bcc,
+                 subject, html_body, text_body, headers, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    email.id,
+                    email.sender,
+                    json.dumps(email.to),
+                    json.dumps(email.cc),
+                    json.dumps(email.bcc),
+                    email.subject,
+                    email.html_body,
+                    email.text_body,
+                    json.dumps(email.headers),
+                    email.created_at.isoformat(),
+                ),
+            )
+
+            # Delete existing attachments and re-insert
+            await db.execute("DELETE FROM attachments WHERE email_id = ?", (email.id,))
+            for attachment in email.attachments:
+                await db.execute(
+                    """
+                    INSERT INTO attachments
+                    (email_id, filename, content_type, size, content)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        email.id,
+                        attachment.filename,
+                        attachment.content_type,
+                        attachment.size,
+                        attachment.content,
+                    ),
+                )
+
+            await db.commit()
+
+    async def get_all(self) -> list[Email]:
+        """Get all emails, ordered by created_at descending.
+
+        Returns:
+            List of emails (without attachment content)
+        """
+
+        await self._ensure_initialized()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                """
+                SELECT * FROM emails ORDER BY created_at DESC
+                """
+            ) as cursor:
+                rows = await cursor.fetchall()
+
+        return [self._row_to_email(row) for row in rows]
+
+    async def get_by_id(self, email_id: str) -> Email | None:
+        """Get a single email by ID.
+
+        Args:
+            email_id: Email ID to fetch
+
+        Returns:
+            Email if found, None otherwise
+        """
+        from mailview.models import Attachment
+
+        await self._ensure_initialized()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+
+            async with db.execute(
+                "SELECT * FROM emails WHERE id = ?", (email_id,)
+            ) as cursor:
+                row = await cursor.fetchone()
+
+            if row is None:
+                return None
+
+            email = self._row_to_email(row)
+
+            # Load attachments with content
+            async with db.execute(
+                "SELECT * FROM attachments WHERE email_id = ?", (email_id,)
+            ) as cursor:
+                attachment_rows = await cursor.fetchall()
+
+            email.attachments = [
+                Attachment(
+                    filename=a["filename"],
+                    content_type=a["content_type"],
+                    size=a["size"],
+                    content=a["content"],
+                )
+                for a in attachment_rows
+            ]
+
+        return email
+
+    async def get_attachment(self, email_id: str, filename: str) -> Attachment | None:
+        """Get a specific attachment.
+
+        Args:
+            email_id: Email ID
+            filename: Attachment filename
+
+        Returns:
+            Attachment if found, None otherwise
+        """
+        from mailview.models import Attachment
+
+        await self._ensure_initialized()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                """
+                SELECT * FROM attachments
+                WHERE email_id = ? AND filename = ?
+                """,
+                (email_id, filename),
+            ) as cursor:
+                row = await cursor.fetchone()
+
+        if row is None:
+            return None
+
+        return Attachment(
+            filename=row["filename"],
+            content_type=row["content_type"],
+            size=row["size"],
+            content=row["content"],
+        )
+
+    async def delete(self, email_id: str) -> bool:
+        """Delete a single email.
+
+        Args:
+            email_id: Email ID to delete
+
+        Returns:
+            True if deleted, False if not found
+        """
+        await self._ensure_initialized()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("PRAGMA foreign_keys = ON")
+            cursor = await db.execute("DELETE FROM emails WHERE id = ?", (email_id,))
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def delete_all(self) -> int:
+        """Delete all emails.
+
+        Returns:
+            Number of emails deleted
+        """
+        await self._ensure_initialized()
+
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute("DELETE FROM emails")
+            await db.execute("DELETE FROM attachments")
+            await db.commit()
+            return cursor.rowcount
+
+    async def count(self) -> int:
+        """Get total email count.
+
+        Returns:
+            Number of stored emails
+        """
+        await self._ensure_initialized()
+
+        async with (
+            aiosqlite.connect(self.db_path) as db,
+            db.execute("SELECT COUNT(*) FROM emails") as cursor,
+        ):
+            row = await cursor.fetchone()
+            return row[0] if row else 0
+
+    def _row_to_email(self, row: aiosqlite.Row) -> Email:
+        """Convert database row to Email object."""
+        from mailview.models import Email
+
+        # Use from_dict to ensure created_at is parsed to datetime
+        return Email.from_dict(
+            {
+                "id": row["id"],
+                "sender": row["sender"] or "",
+                "to": json.loads(row["recipients_to"] or "[]"),
+                "cc": json.loads(row["recipients_cc"] or "[]"),
+                "bcc": json.loads(row["recipients_bcc"] or "[]"),
+                "subject": row["subject"] or "",
+                "html_body": row["html_body"],
+                "text_body": row["text_body"],
+                "headers": json.loads(row["headers"] or "{}"),
+                "created_at": row["created_at"],
+            }
+        )

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,277 @@
+"""Tests for SQLite storage layer."""
+
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from mailview.models import Attachment, Email
+from mailview.store import EmailStore
+
+
+@pytest.fixture
+def temp_db_path():
+    """Create a temporary database path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield str(Path(tmpdir) / "test.db")
+
+
+@pytest.fixture
+def store(temp_db_path):
+    """Create a store with temporary database."""
+    return EmailStore(db_path=temp_db_path)
+
+
+@pytest.fixture
+def sample_email():
+    """Create a sample email for testing."""
+    return Email(
+        id="test-email-123",
+        sender="sender@example.com",
+        to=["to@example.com"],
+        cc=["cc@example.com"],
+        subject="Test Subject",
+        html_body="<p>Hello World</p>",
+        text_body="Hello World",
+        headers={"X-Custom": "value"},
+    )
+
+
+@pytest.fixture
+def email_with_attachment():
+    """Create an email with attachment."""
+    return Email(
+        id="email-with-attach",
+        sender="sender@example.com",
+        to=["to@example.com"],
+        subject="With Attachment",
+        html_body="<p>See attached</p>",
+        attachments=[
+            Attachment(
+                filename="test.txt",
+                content_type="text/plain",
+                size=13,
+                content=b"Hello, World!",
+            ),
+            Attachment(
+                filename="image.png",
+                content_type="image/png",
+                size=100,
+                content=b"fake png data",
+            ),
+        ],
+    )
+
+
+class TestEmailStoreInit:
+    """Tests for store initialization."""
+
+    async def test_creates_directory(self, temp_db_path):
+        """Test that store creates directory if needed."""
+        nested_path = str(Path(temp_db_path).parent / "nested" / "dir" / "test.db")
+        store = EmailStore(db_path=nested_path)
+        await store._ensure_initialized()
+        assert Path(nested_path).parent.exists()
+
+    async def test_creates_tables(self, store, temp_db_path):
+        """Test that tables are created on init."""
+        await store._ensure_initialized()
+        assert Path(temp_db_path).exists()
+
+
+class TestEmailStoreSave:
+    """Tests for saving emails."""
+
+    async def test_save_email(self, store, sample_email):
+        """Test saving a basic email."""
+        await store.save(sample_email)
+        count = await store.count()
+        assert count == 1
+
+    async def test_save_multiple_emails(self, store):
+        """Test saving multiple emails."""
+        for i in range(5):
+            email = Email(id=f"email-{i}", subject=f"Email {i}")
+            await store.save(email)
+        count = await store.count()
+        assert count == 5
+
+    async def test_save_email_with_attachments(self, store, email_with_attachment):
+        """Test saving email with attachments."""
+        await store.save(email_with_attachment)
+        retrieved = await store.get_by_id(email_with_attachment.id)
+        assert len(retrieved.attachments) == 2
+
+    async def test_save_replaces_existing(self, store, sample_email):
+        """Test that saving with same ID replaces."""
+        await store.save(sample_email)
+        sample_email.subject = "Updated Subject"
+        await store.save(sample_email)
+
+        count = await store.count()
+        assert count == 1
+
+        retrieved = await store.get_by_id(sample_email.id)
+        assert retrieved.subject == "Updated Subject"
+
+
+class TestEmailStoreGetAll:
+    """Tests for getting all emails."""
+
+    async def test_get_all_empty(self, store):
+        """Test get_all on empty store."""
+        emails = await store.get_all()
+        assert emails == []
+
+    async def test_get_all_returns_emails(self, store, sample_email):
+        """Test get_all returns saved emails."""
+        await store.save(sample_email)
+        emails = await store.get_all()
+        assert len(emails) == 1
+        assert emails[0].id == sample_email.id
+
+    async def test_get_all_ordered_by_created_at(self, store):
+        """Test emails are ordered newest first."""
+        from datetime import UTC, datetime
+
+        old_email = Email(
+            id="old",
+            subject="Old",
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        new_email = Email(
+            id="new",
+            subject="New",
+            created_at=datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        await store.save(old_email)
+        await store.save(new_email)
+
+        emails = await store.get_all()
+        assert emails[0].id == "new"
+        assert emails[1].id == "old"
+
+
+class TestEmailStoreGetById:
+    """Tests for getting single email."""
+
+    async def test_get_by_id_found(self, store, sample_email):
+        """Test getting existing email."""
+        await store.save(sample_email)
+        retrieved = await store.get_by_id(sample_email.id)
+
+        assert retrieved is not None
+        assert retrieved.id == sample_email.id
+        assert retrieved.sender == sample_email.sender
+        assert retrieved.to == sample_email.to
+        assert retrieved.subject == sample_email.subject
+        assert retrieved.html_body == sample_email.html_body
+        assert retrieved.text_body == sample_email.text_body
+        # Verify created_at round-trips as datetime, not string
+        assert isinstance(retrieved.created_at, datetime)
+        assert retrieved.created_at.tzinfo is not None
+
+    async def test_get_by_id_not_found(self, store):
+        """Test getting non-existent email."""
+        retrieved = await store.get_by_id("does-not-exist")
+        assert retrieved is None
+
+    async def test_get_by_id_includes_attachments(self, store, email_with_attachment):
+        """Test that get_by_id includes attachment content."""
+        await store.save(email_with_attachment)
+        retrieved = await store.get_by_id(email_with_attachment.id)
+
+        assert len(retrieved.attachments) == 2
+        assert retrieved.attachments[0].filename == "test.txt"
+        assert retrieved.attachments[0].content == b"Hello, World!"
+
+
+class TestEmailStoreGetAttachment:
+    """Tests for getting attachments."""
+
+    async def test_get_attachment_found(self, store, email_with_attachment):
+        """Test getting existing attachment."""
+        await store.save(email_with_attachment)
+        attachment = await store.get_attachment(email_with_attachment.id, "test.txt")
+
+        assert attachment is not None
+        assert attachment.filename == "test.txt"
+        assert attachment.content_type == "text/plain"
+        assert attachment.content == b"Hello, World!"
+
+    async def test_get_attachment_not_found(self, store, email_with_attachment):
+        """Test getting non-existent attachment."""
+        await store.save(email_with_attachment)
+        attachment = await store.get_attachment(
+            email_with_attachment.id, "nonexistent.txt"
+        )
+        assert attachment is None
+
+    async def test_get_attachment_wrong_email(self, store, email_with_attachment):
+        """Test getting attachment with wrong email ID."""
+        await store.save(email_with_attachment)
+        attachment = await store.get_attachment("wrong-id", "test.txt")
+        assert attachment is None
+
+
+class TestEmailStoreDelete:
+    """Tests for deleting emails."""
+
+    async def test_delete_existing(self, store, sample_email):
+        """Test deleting existing email."""
+        await store.save(sample_email)
+        result = await store.delete(sample_email.id)
+
+        assert result is True
+        count = await store.count()
+        assert count == 0
+
+    async def test_delete_non_existing(self, store):
+        """Test deleting non-existent email."""
+        result = await store.delete("does-not-exist")
+        assert result is False
+
+    async def test_delete_removes_attachments(self, store, email_with_attachment):
+        """Test that deleting email removes attachments."""
+        await store.save(email_with_attachment)
+        await store.delete(email_with_attachment.id)
+
+        attachment = await store.get_attachment(email_with_attachment.id, "test.txt")
+        assert attachment is None
+
+
+class TestEmailStoreDeleteAll:
+    """Tests for clearing all emails."""
+
+    async def test_delete_all_empty(self, store):
+        """Test delete_all on empty store."""
+        count = await store.delete_all()
+        assert count == 0
+
+    async def test_delete_all_with_emails(self, store):
+        """Test delete_all removes all emails."""
+        for i in range(3):
+            await store.save(Email(id=f"email-{i}"))
+
+        count = await store.delete_all()
+        assert count == 3
+
+        remaining = await store.count()
+        assert remaining == 0
+
+
+class TestEmailStoreCount:
+    """Tests for counting emails."""
+
+    async def test_count_empty(self, store):
+        """Test count on empty store."""
+        count = await store.count()
+        assert count == 0
+
+    async def test_count_with_emails(self, store):
+        """Test count with emails."""
+        for i in range(7):
+            await store.save(Email(id=f"email-{i}"))
+        count = await store.count()
+        assert count == 7


### PR DESCRIPTION
## Summary
Async SQLite storage layer for captured emails using aiosqlite.

### Changes
- `EmailStore` class with full CRUD operations
- Auto-creates `/tmp/mailview/mailview.db` on first use
- Stores emails with metadata, bodies, headers
- Attachment storage with binary content in separate table
- Foreign key cascade for automatic attachment cleanup

### API
- `save(email)` - Store or update email
- `get_all()` - List all emails (newest first)
- `get_by_id(id)` - Get single email with attachments
- `get_attachment(email_id, filename)` - Get attachment content
- `delete(id)` - Delete single email
- `delete_all()` - Clear all emails
- `count()` - Get email count

### Testing
- 22 unit tests with real SQLite (temp files, no mocking)
- Tests for all CRUD operations
- Attachment handling tests
- Cascade delete verification

### Dependencies
- Depends on #18 (Email data model)

Closes #6