### PR TITLE
🛤️ Add API router for mailview UI

### DIFF
--- a/mailview/__init__.py
+++ b/mailview/__init__.py
@@ -2,6 +2,7 @@
 
 from mailview.backend import MailviewBackend, capture_email
 from mailview.models import Attachment, Email
+from mailview.router import MailviewRouter, create_routes
 from mailview.store import EmailStore
 
 __version__ = "0.1.0"
@@ -12,5 +13,7 @@ __all__ = [
     "Attachment",
     "EmailStore",
     "MailviewBackend",
+    "MailviewRouter",
     "capture_email",
+    "create_routes",
 ]

--- a/mailview/router.py
+++ b/mailview/router.py
@@ -1,0 +1,147 @@
+"""API router for mailview UI.
+
+Provides endpoints for listing, viewing, and managing captured emails.
+"""
+
+from __future__ import annotations
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import Route
+
+from mailview.store import EmailStore
+
+
+class MailviewRouter:
+    """Router for mailview API endpoints.
+
+    All routes are prefixed with /_mail/api.
+    """
+
+    def __init__(self, store: EmailStore | None = None) -> None:
+        """Initialize router with optional store.
+
+        Args:
+            store: EmailStore instance. Creates default if not provided.
+        """
+        self.store = store or EmailStore()
+
+    @property
+    def routes(self) -> list[Route]:
+        """Get list of Starlette routes."""
+        p = "/_mail/api/emails"
+        return [
+            Route(p, self.list_emails, methods=["GET"]),
+            Route(p, self.delete_all_emails, methods=["DELETE"]),
+            Route(f"{p}/{{email_id}}", self.get_email, methods=["GET"]),
+            Route(f"{p}/{{email_id}}", self.delete_email, methods=["DELETE"]),
+            Route(f"{p}/{{email_id}}/html", self.get_email_html, methods=["GET"]),
+            Route(
+                f"{p}/{{email_id}}/attachments/{{filename:path}}",
+                self.get_attachment,
+                methods=["GET"],
+            ),
+        ]
+
+    async def list_emails(self, request: Request) -> JSONResponse:
+        """List all captured emails.
+
+        Returns JSON array of email summaries (without bodies or attachments).
+        """
+        emails = await self.store.get_all()
+        summaries = []
+        for email in emails:
+            data = email.to_dict(include_bodies=False)
+            # get_all() doesn't populate attachments; remove misleading empty list
+            data.pop("attachments", None)
+            summaries.append(data)
+        return JSONResponse({"emails": summaries})
+
+    async def get_email(self, request: Request) -> JSONResponse:
+        """Get a single email by ID.
+
+        Returns full email including bodies.
+        """
+        email_id = request.path_params["email_id"]
+        email = await self.store.get_by_id(email_id)
+
+        if email is None:
+            return JSONResponse({"error": "Email not found"}, status_code=404)
+
+        return JSONResponse({"email": email.to_dict(include_bodies=True)})
+
+    async def get_email_html(self, request: Request) -> Response:
+        """Get HTML body for iframe rendering.
+
+        Returns raw HTML with text/html content type.
+        """
+        email_id = request.path_params["email_id"]
+        email = await self.store.get_by_id(email_id)
+
+        if email is None:
+            return JSONResponse({"error": "Email not found"}, status_code=404)
+
+        if not email.html_body:
+            return Response(
+                content="<p>No HTML content</p>",
+                media_type="text/html",
+            )
+
+        return Response(content=email.html_body, media_type="text/html")
+
+    async def get_attachment(self, request: Request) -> Response:
+        """Download an attachment.
+
+        Returns attachment content with appropriate content type.
+        """
+        email_id = request.path_params["email_id"]
+        filename = request.path_params["filename"]
+
+        # Check email exists first for clearer error messages
+        email = await self.store.get_by_id(email_id)
+        if email is None:
+            return JSONResponse({"error": "Email not found"}, status_code=404)
+
+        attachment = await self.store.get_attachment(email_id, filename)
+        if attachment is None:
+            return JSONResponse({"error": "Attachment not found"}, status_code=404)
+
+        # Sanitize filename for Content-Disposition header
+        safe_filename = (
+            attachment.filename.replace("\r", "").replace("\n", "").replace('"', '\\"')
+        )
+        return Response(
+            content=attachment.content,
+            media_type=attachment.content_type,
+            headers={"Content-Disposition": f'attachment; filename="{safe_filename}"'},
+        )
+
+    async def delete_email(self, request: Request) -> JSONResponse:
+        """Delete a single email."""
+        email_id = request.path_params["email_id"]
+        deleted = await self.store.delete(email_id)
+
+        if not deleted:
+            return JSONResponse({"error": "Email not found"}, status_code=404)
+
+        return JSONResponse({"deleted": True})
+
+    async def delete_all_emails(self, request: Request) -> JSONResponse:
+        """Delete all captured emails."""
+        count = await self.store.delete_all()
+        return JSONResponse({"deleted": count})
+
+
+def create_routes(store: EmailStore | None = None) -> list[Route]:
+    """Create mailview API routes.
+
+    Convenience function for getting routes without instantiating router.
+
+    Args:
+        store: Optional EmailStore instance
+
+    Returns:
+        List of Starlette Route objects
+    """
+    router = MailviewRouter(store=store)
+    return router.routes

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,256 @@
+"""Tests for API router."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from starlette.routing import Router
+from starlette.testclient import TestClient
+
+from mailview.models import Attachment, Email
+from mailview.router import MailviewRouter, create_routes
+from mailview.store import EmailStore
+
+
+@pytest.fixture
+def temp_db_path():
+    """Create a temporary database path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield str(Path(tmpdir) / "test.db")
+
+
+@pytest.fixture
+def store(temp_db_path):
+    """Create a store with temporary database."""
+    return EmailStore(db_path=temp_db_path)
+
+
+@pytest.fixture
+def router(store):
+    """Create a router with test store."""
+    return MailviewRouter(store=store)
+
+
+@pytest.fixture
+def client(router):
+    """Create a test client for the router."""
+    app = Router(routes=router.routes)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def sample_email():
+    """Create a sample email for testing."""
+    return Email(
+        id="test-email-123",
+        sender="sender@example.com",
+        to=["recipient@example.com"],
+        subject="Test Subject",
+        html_body="<p>Hello World</p>",
+        text_body="Hello World",
+    )
+
+
+@pytest.fixture
+def email_with_attachment():
+    """Create an email with attachment."""
+    return Email(
+        id="email-with-attach",
+        sender="sender@example.com",
+        to=["recipient@example.com"],
+        subject="With Attachment",
+        html_body="<p>See attached</p>",
+        attachments=[
+            Attachment(
+                filename="document.pdf",
+                content_type="application/pdf",
+                size=13,
+                content=b"PDF content here",
+            ),
+        ],
+    )
+
+
+class TestListEmails:
+    """Tests for GET /emails endpoint."""
+
+    async def test_list_empty(self, client):
+        """Test listing with no emails."""
+        response = client.get("/_mail/api/emails")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["emails"] == []
+
+    async def test_list_with_emails(self, client, store, sample_email):
+        """Test listing with emails."""
+        await store.save(sample_email)
+
+        response = client.get("/_mail/api/emails")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["emails"]) == 1
+        assert data["emails"][0]["id"] == "test-email-123"
+        assert data["emails"][0]["subject"] == "Test Subject"
+
+    async def test_list_excludes_bodies(self, client, store, sample_email):
+        """Test that listing excludes email bodies and attachments."""
+        await store.save(sample_email)
+
+        response = client.get("/_mail/api/emails")
+        data = response.json()
+        assert "html_body" not in data["emails"][0]
+        assert "text_body" not in data["emails"][0]
+        assert "attachments" not in data["emails"][0]
+        # But includes has_html/has_text flags
+        assert data["emails"][0]["has_html"] is True
+        assert data["emails"][0]["has_text"] is True
+
+
+class TestGetEmail:
+    """Tests for GET /emails/{id} endpoint."""
+
+    async def test_get_existing(self, client, store, sample_email):
+        """Test getting existing email."""
+        await store.save(sample_email)
+
+        response = client.get("/_mail/api/emails/test-email-123")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["email"]["id"] == "test-email-123"
+        assert data["email"]["html_body"] == "<p>Hello World</p>"
+        assert data["email"]["text_body"] == "Hello World"
+
+    async def test_get_not_found(self, client):
+        """Test getting non-existent email."""
+        response = client.get("/_mail/api/emails/does-not-exist")
+        assert response.status_code == 404
+        assert response.json()["error"] == "Email not found"
+
+
+class TestGetEmailHtml:
+    """Tests for GET /emails/{id}/html endpoint."""
+
+    async def test_get_html_body(self, client, store, sample_email):
+        """Test getting HTML body."""
+        await store.save(sample_email)
+
+        response = client.get("/_mail/api/emails/test-email-123/html")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/html; charset=utf-8"
+        assert response.text == "<p>Hello World</p>"
+
+    async def test_get_html_no_body(self, client, store):
+        """Test getting HTML when email has no HTML body."""
+        email = Email(id="text-only", text_body="Plain text only")
+        await store.save(email)
+
+        response = client.get("/_mail/api/emails/text-only/html")
+        assert response.status_code == 200
+        assert "<p>No HTML content</p>" in response.text
+
+    async def test_get_html_not_found(self, client):
+        """Test getting HTML for non-existent email."""
+        response = client.get("/_mail/api/emails/does-not-exist/html")
+        assert response.status_code == 404
+
+
+class TestGetAttachment:
+    """Tests for GET /emails/{id}/attachments/{filename} endpoint."""
+
+    async def test_get_attachment(self, client, store, email_with_attachment):
+        """Test downloading attachment."""
+        await store.save(email_with_attachment)
+
+        url = "/_mail/api/emails/email-with-attach/attachments/document.pdf"
+        response = client.get(url)
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/pdf"
+        assert "attachment" in response.headers["content-disposition"]
+        assert "document.pdf" in response.headers["content-disposition"]
+        assert response.content == b"PDF content here"
+
+    async def test_get_attachment_not_found(self, client, store, sample_email):
+        """Test downloading non-existent attachment."""
+        await store.save(sample_email)
+
+        url = "/_mail/api/emails/test-email-123/attachments/missing.pdf"
+        response = client.get(url)
+        assert response.status_code == 404
+        assert response.json()["error"] == "Attachment not found"
+
+    async def test_get_attachment_email_not_found(self, client):
+        """Test downloading attachment from non-existent email."""
+        response = client.get("/_mail/api/emails/no-email/attachments/file.pdf")
+        assert response.status_code == 404
+        assert response.json()["error"] == "Email not found"
+
+
+class TestDeleteEmail:
+    """Tests for DELETE /emails/{id} endpoint."""
+
+    async def test_delete_existing(self, client, store, sample_email):
+        """Test deleting existing email."""
+        await store.save(sample_email)
+
+        response = client.delete("/_mail/api/emails/test-email-123")
+        assert response.status_code == 200
+        assert response.json()["deleted"] is True
+
+        # Verify deleted
+        assert await store.get_by_id("test-email-123") is None
+
+    async def test_delete_not_found(self, client):
+        """Test deleting non-existent email."""
+        response = client.delete("/_mail/api/emails/does-not-exist")
+        assert response.status_code == 404
+        assert response.json()["error"] == "Email not found"
+
+
+class TestDeleteAllEmails:
+    """Tests for DELETE /emails endpoint."""
+
+    async def test_delete_all(self, client, store):
+        """Test deleting all emails."""
+        for i in range(3):
+            await store.save(Email(id=f"email-{i}", subject=f"Email {i}"))
+
+        response = client.delete("/_mail/api/emails")
+        assert response.status_code == 200
+        assert response.json()["deleted"] == 3
+
+        # Verify all deleted
+        assert await store.count() == 0
+
+    async def test_delete_all_empty(self, client):
+        """Test deleting all when already empty."""
+        response = client.delete("/_mail/api/emails")
+        assert response.status_code == 200
+        assert response.json()["deleted"] == 0
+
+
+class TestCreateRoutes:
+    """Tests for create_routes convenience function."""
+
+    def test_creates_routes(self):
+        """Test that create_routes returns route list."""
+        routes = create_routes()
+        assert len(routes) == 6
+
+    def test_creates_routes_with_store(self, store):
+        """Test that create_routes accepts store."""
+        routes = create_routes(store=store)
+        assert len(routes) == 6
+
+
+class TestMailviewRouterInit:
+    """Tests for router initialization."""
+
+    def test_creates_default_store(self):
+        """Test that router creates default store if none provided."""
+        router = MailviewRouter()
+        assert router.store is not None
+
+    def test_uses_provided_store(self, store):
+        """Test that router uses provided store."""
+        router = MailviewRouter(store=store)
+        assert router.store is store


### PR DESCRIPTION
## Summary
- Implements `MailviewRouter` class with Starlette routes for the mailview UI
- All endpoints for listing, viewing, and managing captured emails
- JSON responses for list/get, proper content-types for HTML and attachments

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/emails` | List all captured emails (without bodies) |
| GET | `/emails/{id}` | Get single email with full content |
| GET | `/emails/{id}/html` | Get HTML body for iframe rendering |
| GET | `/emails/{id}/attachments/{filename}` | Download attachment |
| DELETE | `/emails` | Clear all emails |
| DELETE | `/emails/{id}` | Delete single email |

## Test plan
- [x] 19 unit tests covering all endpoints
- [x] Tests for success and error cases (404s)
- [x] Tests for edge cases (empty list, no HTML body)

Closes #8