### PR TITLE
🔌 Add ASGI middleware for mounting mailview

### DIFF
--- a/mailview/__init__.py
+++ b/mailview/__init__.py
@@ -1,6 +1,7 @@
 """Mailview - Zero-config email interceptor for Python ASGI apps."""
 
 from mailview.backend import MailviewBackend, capture_email
+from mailview.middleware import MailviewMiddleware
 from mailview.models import Attachment, Email
 from mailview.router import MailviewRouter, create_routes
 from mailview.store import EmailStore
@@ -13,6 +14,7 @@ __all__ = [
     "Attachment",
     "EmailStore",
     "MailviewBackend",
+    "MailviewMiddleware",
     "MailviewRouter",
     "capture_email",
     "create_routes",

--- a/mailview/middleware.py
+++ b/mailview/middleware.py
@@ -1,0 +1,119 @@
+"""ASGI middleware for mailview.
+
+Mounts the mailview API at a configurable path.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from starlette.routing import Router
+
+from mailview.router import MailviewRouter
+from mailview.store import EmailStore
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+def is_dev_environment() -> bool:
+    """Check if running in a development environment.
+
+    Checks common environment indicators:
+    - DEBUG env var is set and truthy
+    - ENVIRONMENT/ENV is "development" or "dev"
+    - FASTAPI_ENV is "development"
+    - FLASK_ENV is "development"
+
+    Returns:
+        True if development environment detected
+    """
+    # Check DEBUG flag
+    debug = os.environ.get("DEBUG", "").lower()
+    if debug in ("1", "true", "yes"):
+        return True
+
+    # Check various ENV variables
+    for var in ("ENVIRONMENT", "ENV", "FASTAPI_ENV", "FLASK_ENV"):
+        env = os.environ.get(var, "").lower()
+        if env in ("development", "dev"):
+            return True
+
+    return False
+
+
+class MailviewMiddleware:
+    """ASGI middleware that mounts mailview API.
+
+    Example:
+        from fastapi import FastAPI
+        from mailview import MailviewMiddleware
+
+        app = FastAPI()
+        app.add_middleware(MailviewMiddleware)
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        mount_path: str = "/_mail",
+        db_path: str | None = None,
+        enabled: bool | None = None,
+    ) -> None:
+        """Initialize middleware.
+
+        Args:
+            app: The ASGI application to wrap
+            mount_path: URL path to mount mailview (default: /_mail)
+            db_path: Custom database path (default: /tmp/mailview/mailview.db)
+            enabled: Force enable/disable. If None, auto-detect dev environment.
+        """
+        self.app = app
+        self.mount_path = self._normalize_mount_path(mount_path)
+        self.enabled = enabled if enabled is not None else is_dev_environment()
+
+        if self.enabled:
+            # Create store and router
+            self.store = EmailStore(db_path=db_path) if db_path else EmailStore()
+            self.router = MailviewRouter(store=self.store, mount_path=self.mount_path)
+
+            # Create mounted router for API
+            api_routes = self.router.routes
+            self._mailview_app: ASGIApp = Router(routes=api_routes)
+        else:
+            self._mailview_app = None
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Handle ASGI request."""
+        if not self.enabled:
+            await self.app(scope, receive, send)
+            return
+
+        if scope["type"] == "http":
+            path = scope.get("path", "")
+
+            # Check if request is for mailview (boundary-aware)
+            if path == self.mount_path or path.startswith(self.mount_path + "/"):
+                # Route to mailview app
+                await self._mailview_app(scope, receive, send)
+                return
+
+        # Pass through to wrapped app
+        await self.app(scope, receive, send)
+
+    @staticmethod
+    def _normalize_mount_path(mount_path: str) -> str:
+        """Normalize and validate mount_path."""
+        path = mount_path.strip().rstrip("/")
+        if not path or path == "/":
+            raise ValueError("mount_path must be a non-empty, non-root path")
+        if not path.startswith("/"):
+            path = "/" + path
+        return path
+
+    @property
+    def mailview_store(self) -> EmailStore | None:
+        """Get the EmailStore instance for email capture integration."""
+        return self.store if self.enabled else None

--- a/mailview/router.py
+++ b/mailview/router.py
@@ -15,21 +15,37 @@ from mailview.store import EmailStore
 class MailviewRouter:
     """Router for mailview API endpoints.
 
-    All routes are prefixed with /_mail/api.
+    Routes are prefixed with {mount_path}/api/emails.
     """
 
-    def __init__(self, store: EmailStore | None = None) -> None:
+    def __init__(
+        self,
+        store: EmailStore | None = None,
+        mount_path: str = "/_mail",
+    ) -> None:
         """Initialize router with optional store.
 
         Args:
             store: EmailStore instance. Creates default if not provided.
+            mount_path: URL path prefix for routes (default: /_mail)
         """
         self.store = store or EmailStore()
+        self.mount_path = self._normalize_mount_path(mount_path)
+
+    @staticmethod
+    def _normalize_mount_path(mount_path: str) -> str:
+        """Normalize and validate mount_path."""
+        path = mount_path.strip().rstrip("/")
+        if not path or path == "/":
+            raise ValueError("mount_path must be a non-empty, non-root path")
+        if not path.startswith("/"):
+            path = "/" + path
+        return path
 
     @property
     def routes(self) -> list[Route]:
         """Get list of Starlette routes."""
-        p = "/_mail/api/emails"
+        p = f"{self.mount_path}/api/emails"
         return [
             Route(p, self.list_emails, methods=["GET"]),
             Route(p, self.delete_all_emails, methods=["DELETE"]),
@@ -132,16 +148,20 @@ class MailviewRouter:
         return JSONResponse({"deleted": count})
 
 
-def create_routes(store: EmailStore | None = None) -> list[Route]:
+def create_routes(
+    store: EmailStore | None = None,
+    mount_path: str = "/_mail",
+) -> list[Route]:
     """Create mailview API routes.
 
     Convenience function for getting routes without instantiating router.
 
     Args:
         store: Optional EmailStore instance
+        mount_path: URL path prefix for routes (default: /_mail)
 
     Returns:
         List of Starlette Route objects
     """
-    router = MailviewRouter(store=store)
+    router = MailviewRouter(store=store, mount_path=mount_path)
     return router.routes

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,244 @@
+"""Tests for ASGI middleware."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from mailview.middleware import MailviewMiddleware, is_dev_environment
+from mailview.models import Email
+
+
+@pytest.fixture
+def temp_db_path():
+    """Create a temporary database path."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield str(Path(tmpdir) / "test.db")
+
+
+def homepage(request):
+    """Simple homepage handler."""
+    return PlainTextResponse("Hello from app")
+
+
+def create_app(middleware_kwargs=None):
+    """Create a test Starlette app with middleware."""
+    app = Starlette(routes=[Route("/", homepage)])
+    kwargs = middleware_kwargs or {}
+    return MailviewMiddleware(app, **kwargs)
+
+
+class TestIsDevEnvironment:
+    """Tests for dev environment detection."""
+
+    def test_debug_true(self):
+        """Test DEBUG=1 is detected."""
+        with patch.dict(os.environ, {"DEBUG": "1"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_debug_true_string(self):
+        """Test DEBUG=true is detected."""
+        with patch.dict(os.environ, {"DEBUG": "true"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_environment_development(self):
+        """Test ENVIRONMENT=development is detected."""
+        with patch.dict(os.environ, {"ENVIRONMENT": "development"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_env_dev(self):
+        """Test ENV=dev is detected."""
+        with patch.dict(os.environ, {"ENV": "dev"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_fastapi_env(self):
+        """Test FASTAPI_ENV=development is detected."""
+        with patch.dict(os.environ, {"FASTAPI_ENV": "development"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_flask_env(self):
+        """Test FLASK_ENV=development is detected."""
+        with patch.dict(os.environ, {"FLASK_ENV": "development"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_production_not_detected(self):
+        """Test production environment is not detected as dev."""
+        with patch.dict(os.environ, {"ENVIRONMENT": "production"}, clear=True):
+            assert is_dev_environment() is False
+
+    def test_no_env_vars(self):
+        """Test no env vars returns False."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert is_dev_environment() is False
+
+
+class TestMiddlewareInit:
+    """Tests for middleware initialization."""
+
+    def test_default_mount_path(self, temp_db_path):
+        """Test default mount path is /_mail."""
+        app = create_app({"enabled": True, "db_path": temp_db_path})
+        assert app.mount_path == "/_mail"
+
+    def test_custom_mount_path(self, temp_db_path):
+        """Test custom mount path."""
+        app = create_app(
+            {
+                "enabled": True,
+                "db_path": temp_db_path,
+                "mount_path": "/_emails",
+            }
+        )
+        assert app.mount_path == "/_emails"
+
+    def test_mount_path_strips_trailing_slash(self, temp_db_path):
+        """Test trailing slash is stripped from mount path."""
+        app = create_app(
+            {
+                "enabled": True,
+                "db_path": temp_db_path,
+                "mount_path": "/_mail/",
+            }
+        )
+        assert app.mount_path == "/_mail"
+
+    def test_enabled_true(self, temp_db_path):
+        """Test explicitly enabled."""
+        app = create_app({"enabled": True, "db_path": temp_db_path})
+        assert app.enabled is True
+        assert app._mailview_app is not None
+
+    def test_enabled_false(self, temp_db_path):
+        """Test explicitly disabled."""
+        app = create_app({"enabled": False})
+        assert app.enabled is False
+        assert app._mailview_app is None
+
+    def test_auto_detect_dev(self, temp_db_path):
+        """Test auto-detection when enabled=None."""
+        with patch.dict(os.environ, {"DEBUG": "1"}, clear=True):
+            app = create_app({"db_path": temp_db_path})
+            assert app.enabled is True
+
+    def test_auto_detect_prod(self):
+        """Test auto-detection in production."""
+        with patch.dict(os.environ, {"ENVIRONMENT": "production"}, clear=True):
+            app = create_app()
+            assert app.enabled is False
+
+    def test_custom_db_path(self, temp_db_path):
+        """Test custom database path."""
+        app = create_app({"enabled": True, "db_path": temp_db_path})
+        assert app.store.db_path == temp_db_path
+
+    def test_empty_mount_path_raises(self):
+        """Test that empty mount_path raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty"):
+            create_app({"enabled": True, "mount_path": ""})
+
+    def test_root_mount_path_raises(self):
+        """Test that root mount_path raises ValueError."""
+        with pytest.raises(ValueError, match="non-root"):
+            create_app({"enabled": True, "mount_path": "/"})
+
+
+class TestMiddlewareRouting:
+    """Tests for middleware request routing."""
+
+    def test_passthrough_when_disabled(self):
+        """Test requests pass through when disabled."""
+        app = create_app({"enabled": False})
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.text == "Hello from app"
+
+    def test_passthrough_non_mailview_paths(self, temp_db_path):
+        """Test non-mailview paths pass through."""
+        app = create_app({"enabled": True, "db_path": temp_db_path})
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.text == "Hello from app"
+
+    def test_routes_to_mailview_api(self, temp_db_path):
+        """Test mailview API paths are routed correctly."""
+        app = create_app({"enabled": True, "db_path": temp_db_path})
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/_mail/api/emails")
+        assert response.status_code == 200
+        assert "emails" in response.json()
+
+    def test_custom_mount_path_routing(self, temp_db_path):
+        """Test routing with custom mount path."""
+        app = create_app(
+            {
+                "enabled": True,
+                "db_path": temp_db_path,
+                "mount_path": "/_custom",
+            }
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+
+        # Should not route old path
+        response = client.get("/_mail/api/emails")
+        assert response.status_code == 404
+
+        # Should route new path
+        response = client.get("/_custom/api/emails")
+        assert response.status_code == 200
+
+    def test_mount_path_boundary_does_not_match_prefix(self, temp_db_path):
+        """Test default mount path does not capture similarly-prefixed routes."""
+        app = create_app({"enabled": True, "db_path": temp_db_path})
+        client = TestClient(app, raise_server_exceptions=False)
+
+        # Requests to /_mailbox/... should not be handled by the /_mail mount
+        response = client.get("/_mailbox/api/emails")
+        assert response.status_code == 404
+
+
+class TestMiddlewareIntegration:
+    """Integration tests with FastAPI-style usage."""
+
+    async def test_email_capture_integration(self, temp_db_path):
+        """Test capturing and listing emails via middleware."""
+        app = create_app({"enabled": True, "db_path": temp_db_path})
+        store = app.mailview_store
+
+        # Capture an email
+        email = Email(
+            id="integration-test",
+            sender="test@example.com",
+            to=["recipient@example.com"],
+            subject="Integration Test",
+            text_body="Test body",
+        )
+        await store.save(email)
+
+        # List via API
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/_mail/api/emails")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["emails"]) == 1
+        assert data["emails"][0]["subject"] == "Integration Test"
+
+    def test_mailview_store_property_when_enabled(self, temp_db_path):
+        """Test mailview_store property returns store when enabled."""
+        app = create_app({"enabled": True, "db_path": temp_db_path})
+        assert app.mailview_store is not None
+
+    def test_mailview_store_property_when_disabled(self):
+        """Test mailview_store property returns None when disabled."""
+        app = create_app({"enabled": False})
+        assert app.mailview_store is None


### PR DESCRIPTION
## Summary

Adds `MailviewMiddleware` - the main entry point for integrating mailview into ASGI apps.

- ASGI middleware that mounts mailview UI and API at configurable path
- Auto-detects development environment via common env vars (DEBUG, ENVIRONMENT, ENV, FASTAPI_ENV, FLASK_ENV)
- Supports custom `mount_path` (default: `/_mail`) and `db_path` configuration
- Exposes `mailview_store` property for email capture integration
- Updates `MailviewRouter` and `create_routes()` to accept configurable mount_path

### Usage

```python
from fastapi import FastAPI
from mailview import MailviewMiddleware

app = FastAPI()
app.add_middleware(MailviewMiddleware)
```

## Test plan

- [x] Tests for dev environment detection (DEBUG, ENVIRONMENT, ENV, FASTAPI_ENV, FLASK_ENV)
- [x] Tests for middleware initialization (mount_path, db_path, enabled)
- [x] Tests for request routing (passthrough, mailview paths, custom mount paths)
- [x] Integration tests with FastAPI-style usage
- [x] All 118 tests passing
- [x] Linting and security checks passing

Closes #9