### PR TITLE
🔒 Add dev environment detection module

### DIFF
--- a/mailview/__init__.py
+++ b/mailview/__init__.py
@@ -1,8 +1,14 @@
 """Mailview - Zero-config email interceptor for Python ASGI apps."""
 
 from mailview.backend import MailviewBackend, capture_email
+from mailview.env import (
+    is_dev_environment,
+    is_mailview_enabled,
+    is_production_environment,
+)
 from mailview.middleware import MailviewMiddleware
 from mailview.models import Attachment, Email
+from mailview.paths import normalize_mount_path
 from mailview.router import MailviewRouter, create_routes
 from mailview.store import EmailStore
 
@@ -18,4 +24,8 @@ __all__ = [
     "MailviewRouter",
     "capture_email",
     "create_routes",
+    "is_dev_environment",
+    "is_mailview_enabled",
+    "is_production_environment",
+    "normalize_mount_path",
 ]

--- a/mailview/env.py
+++ b/mailview/env.py
@@ -1,0 +1,101 @@
+"""Environment detection for mailview.
+
+Provides functions to detect development environments and control
+mailview activation safely.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger("mailview")
+
+# Canonical truthy/falsy values for env var parsing
+_TRUTHY = frozenset(("1", "true", "yes"))
+_FALSY = frozenset(("0", "false", "no"))
+_DEV_VALUES = frozenset(("development", "dev"))
+_PROD_VALUES = frozenset(("production", "prod", "staging"))
+
+
+def _env_is_truthy(var_name: str) -> bool:
+    """Check if an environment variable has a truthy value."""
+    return os.environ.get(var_name, "").lower() in _TRUTHY
+
+
+def _env_is_falsy(var_name: str) -> bool:
+    """Check if an environment variable has a falsy value."""
+    return os.environ.get(var_name, "").lower() in _FALSY
+
+
+def is_production_environment() -> bool:
+    """Check if running in a production-like environment.
+
+    Returns True if any common production indicators are detected.
+    """
+    for var in ("ENVIRONMENT", "ENV", "FASTAPI_ENV", "FLASK_ENV"):
+        if os.environ.get(var, "").lower() in _PROD_VALUES:
+            return True
+    return False
+
+
+def is_dev_environment() -> bool:
+    """Check if running in a development environment.
+
+    Checks common environment indicators:
+    - DEBUG env var is set and truthy (1, true, yes)
+    - ENVIRONMENT/ENV is "development" or "dev"
+    - FASTAPI_ENV is "development"
+    - FLASK_ENV is "development"
+
+    Returns:
+        True if development environment detected
+    """
+    if _env_is_truthy("DEBUG"):
+        return True
+
+    for var in ("ENVIRONMENT", "ENV", "FASTAPI_ENV", "FLASK_ENV"):
+        if os.environ.get(var, "").lower() in _DEV_VALUES:
+            return True
+
+    return False
+
+
+def is_mailview_enabled() -> bool:
+    """Check if mailview should be enabled.
+
+    Activation rules (in order):
+    1. MAILVIEW_ENABLED=true -> force enable (with warning)
+    2. MAILVIEW_ENABLED=false -> force disable
+    3. Otherwise, auto-detect via is_dev_environment()
+
+    Returns:
+        True if mailview should be enabled
+    """
+    if _env_is_truthy("MAILVIEW_ENABLED"):
+        if is_production_environment():
+            logger.warning(
+                "Mailview force-enabled in PRODUCTION environment via "
+                "MAILVIEW_ENABLED. This exposes captured emails - ensure "
+                "this is intentional!"
+            )
+        else:
+            logger.warning(
+                "Mailview force-enabled via MAILVIEW_ENABLED. "
+                "Ensure this is intentional and not running in production."
+            )
+        return True
+
+    if _env_is_falsy("MAILVIEW_ENABLED"):
+        return False
+
+    # Warn if set to unrecognized value
+    mailview_enabled = os.environ.get("MAILVIEW_ENABLED", "")
+    if mailview_enabled:
+        logger.warning(
+            "MAILVIEW_ENABLED='%s' is not recognized (use true/false/1/0). "
+            "Falling back to auto-detection.",
+            mailview_enabled,
+        )
+
+    return is_dev_environment()

--- a/mailview/middleware.py
+++ b/mailview/middleware.py
@@ -5,42 +5,17 @@ Mounts the mailview API at a configurable path.
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 
 from starlette.routing import Router
 
+from mailview.env import is_mailview_enabled
+from mailview.paths import normalize_mount_path
 from mailview.router import MailviewRouter
 from mailview.store import EmailStore
 
 if TYPE_CHECKING:
     from starlette.types import ASGIApp, Receive, Scope, Send
-
-
-def is_dev_environment() -> bool:
-    """Check if running in a development environment.
-
-    Checks common environment indicators:
-    - DEBUG env var is set and truthy
-    - ENVIRONMENT/ENV is "development" or "dev"
-    - FASTAPI_ENV is "development"
-    - FLASK_ENV is "development"
-
-    Returns:
-        True if development environment detected
-    """
-    # Check DEBUG flag
-    debug = os.environ.get("DEBUG", "").lower()
-    if debug in ("1", "true", "yes"):
-        return True
-
-    # Check various ENV variables
-    for var in ("ENVIRONMENT", "ENV", "FASTAPI_ENV", "FLASK_ENV"):
-        env = os.environ.get(var, "").lower()
-        if env in ("development", "dev"):
-            return True
-
-    return False
 
 
 class MailviewMiddleware:
@@ -71,8 +46,8 @@ class MailviewMiddleware:
             enabled: Force enable/disable. If None, auto-detect dev environment.
         """
         self.app = app
-        self.mount_path = self._normalize_mount_path(mount_path)
-        self.enabled = enabled if enabled is not None else is_dev_environment()
+        self.mount_path = normalize_mount_path(mount_path)
+        self.enabled = enabled if enabled is not None else is_mailview_enabled()
 
         if self.enabled:
             # Create store and router
@@ -102,16 +77,6 @@ class MailviewMiddleware:
 
         # Pass through to wrapped app
         await self.app(scope, receive, send)
-
-    @staticmethod
-    def _normalize_mount_path(mount_path: str) -> str:
-        """Normalize and validate mount_path."""
-        path = mount_path.strip().rstrip("/")
-        if not path or path == "/":
-            raise ValueError("mount_path must be a non-empty, non-root path")
-        if not path.startswith("/"):
-            path = "/" + path
-        return path
 
     @property
     def mailview_store(self) -> EmailStore | None:

--- a/mailview/paths.py
+++ b/mailview/paths.py
@@ -1,0 +1,23 @@
+"""URL path utilities for mailview."""
+
+from __future__ import annotations
+
+
+def normalize_mount_path(mount_path: str) -> str:
+    """Normalize and validate a URL mount path.
+
+    Args:
+        mount_path: The path to normalize
+
+    Returns:
+        Normalized path (leading slash, no trailing slash)
+
+    Raises:
+        ValueError: If path is empty or root-only
+    """
+    path = mount_path.strip().rstrip("/")
+    if not path or path == "/":
+        raise ValueError("mount_path must be a non-empty, non-root path")
+    if not path.startswith("/"):
+        path = "/" + path
+    return path

--- a/mailview/router.py
+++ b/mailview/router.py
@@ -9,6 +9,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
+from mailview.paths import normalize_mount_path
 from mailview.store import EmailStore
 
 
@@ -30,17 +31,7 @@ class MailviewRouter:
             mount_path: URL path prefix for routes (default: /_mail)
         """
         self.store = store or EmailStore()
-        self.mount_path = self._normalize_mount_path(mount_path)
-
-    @staticmethod
-    def _normalize_mount_path(mount_path: str) -> str:
-        """Normalize and validate mount_path."""
-        path = mount_path.strip().rstrip("/")
-        if not path or path == "/":
-            raise ValueError("mount_path must be a non-empty, non-root path")
-        if not path.startswith("/"):
-            path = "/" + path
-        return path
+        self.mount_path = normalize_mount_path(mount_path)
 
     @property
     def routes(self) -> list[Route]:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,207 @@
+"""Tests for environment detection."""
+
+import logging
+import os
+from unittest.mock import patch
+
+from mailview.env import (
+    is_dev_environment,
+    is_mailview_enabled,
+    is_production_environment,
+)
+
+
+class TestIsDevEnvironment:
+    """Tests for dev environment detection."""
+
+    def test_debug_true(self):
+        """Test DEBUG=1 is detected."""
+        with patch.dict(os.environ, {"DEBUG": "1"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_debug_true_string(self):
+        """Test DEBUG=true is detected."""
+        with patch.dict(os.environ, {"DEBUG": "true"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_debug_yes(self):
+        """Test DEBUG=yes is detected."""
+        with patch.dict(os.environ, {"DEBUG": "yes"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_environment_development(self):
+        """Test ENVIRONMENT=development is detected."""
+        with patch.dict(os.environ, {"ENVIRONMENT": "development"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_env_dev(self):
+        """Test ENV=dev is detected."""
+        with patch.dict(os.environ, {"ENV": "dev"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_fastapi_env(self):
+        """Test FASTAPI_ENV=development is detected."""
+        with patch.dict(os.environ, {"FASTAPI_ENV": "development"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_flask_env(self):
+        """Test FLASK_ENV=development is detected."""
+        with patch.dict(os.environ, {"FLASK_ENV": "development"}, clear=True):
+            assert is_dev_environment() is True
+
+    def test_production_not_detected(self):
+        """Test production environment is not detected as dev."""
+        with patch.dict(os.environ, {"ENVIRONMENT": "production"}, clear=True):
+            assert is_dev_environment() is False
+
+    def test_no_env_vars(self):
+        """Test no env vars returns False."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert is_dev_environment() is False
+
+    def test_case_insensitive(self):
+        """Test env var values are case-insensitive."""
+        with patch.dict(os.environ, {"DEBUG": "TRUE"}, clear=True):
+            assert is_dev_environment() is True
+
+        with patch.dict(os.environ, {"ENVIRONMENT": "DEVELOPMENT"}, clear=True):
+            assert is_dev_environment() is True
+
+
+class TestIsMailviewEnabled:
+    """Tests for mailview enabled detection."""
+
+    def test_mailview_enabled_true(self):
+        """Test MAILVIEW_ENABLED=true forces enable."""
+        with patch.dict(os.environ, {"MAILVIEW_ENABLED": "true"}, clear=True):
+            assert is_mailview_enabled() is True
+
+    def test_mailview_enabled_1(self):
+        """Test MAILVIEW_ENABLED=1 forces enable."""
+        with patch.dict(os.environ, {"MAILVIEW_ENABLED": "1"}, clear=True):
+            assert is_mailview_enabled() is True
+
+    def test_mailview_enabled_yes(self):
+        """Test MAILVIEW_ENABLED=yes forces enable."""
+        with patch.dict(os.environ, {"MAILVIEW_ENABLED": "yes"}, clear=True):
+            assert is_mailview_enabled() is True
+
+    def test_mailview_enabled_false(self):
+        """Test MAILVIEW_ENABLED=false forces disable."""
+        with patch.dict(os.environ, {"MAILVIEW_ENABLED": "false"}, clear=True):
+            assert is_mailview_enabled() is False
+
+    def test_mailview_enabled_0(self):
+        """Test MAILVIEW_ENABLED=0 forces disable."""
+        with patch.dict(os.environ, {"MAILVIEW_ENABLED": "0"}, clear=True):
+            assert is_mailview_enabled() is False
+
+    def test_mailview_enabled_no(self):
+        """Test MAILVIEW_ENABLED=no forces disable."""
+        with patch.dict(os.environ, {"MAILVIEW_ENABLED": "no"}, clear=True):
+            assert is_mailview_enabled() is False
+
+    def test_mailview_enabled_overrides_debug(self):
+        """Test MAILVIEW_ENABLED=false overrides DEBUG=true."""
+        env = {"MAILVIEW_ENABLED": "false", "DEBUG": "true"}
+        with patch.dict(os.environ, env, clear=True):
+            assert is_mailview_enabled() is False
+
+    def test_falls_back_to_dev_detection(self):
+        """Test falls back to is_dev_environment when not set."""
+        with patch.dict(os.environ, {"DEBUG": "1"}, clear=True):
+            assert is_mailview_enabled() is True
+
+        with patch.dict(os.environ, {"ENVIRONMENT": "production"}, clear=True):
+            assert is_mailview_enabled() is False
+
+    def test_logs_warning_when_force_enabled(self, caplog):
+        """Test warning is logged when force-enabled."""
+        env = {"MAILVIEW_ENABLED": "true"}
+        with (
+            patch.dict(os.environ, env, clear=True),
+            caplog.at_level(logging.WARNING, logger="mailview"),
+        ):
+            is_mailview_enabled()
+            assert "force-enabled" in caplog.text
+            assert "MAILVIEW_ENABLED" in caplog.text
+
+    def test_no_warning_when_auto_detected(self, caplog):
+        """Test no warning when auto-detected as dev."""
+        with (
+            patch.dict(os.environ, {"DEBUG": "1"}, clear=True),
+            caplog.at_level(logging.WARNING, logger="mailview"),
+        ):
+            is_mailview_enabled()
+            assert "force-enabled" not in caplog.text
+
+    def test_case_insensitive(self):
+        """Test MAILVIEW_ENABLED values are case-insensitive."""
+        with patch.dict(os.environ, {"MAILVIEW_ENABLED": "TRUE"}, clear=True):
+            assert is_mailview_enabled() is True
+
+        with patch.dict(os.environ, {"MAILVIEW_ENABLED": "FALSE"}, clear=True):
+            assert is_mailview_enabled() is False
+
+    def test_logs_production_warning_when_force_enabled_in_prod(self, caplog):
+        """Test stronger warning is logged when force-enabled in production."""
+        env = {"MAILVIEW_ENABLED": "true", "ENVIRONMENT": "production"}
+        with (
+            patch.dict(os.environ, env, clear=True),
+            caplog.at_level(logging.WARNING, logger="mailview"),
+        ):
+            is_mailview_enabled()
+            assert "PRODUCTION" in caplog.text
+            assert "exposes captured emails" in caplog.text
+
+    def test_warns_on_unrecognized_value(self, caplog):
+        """Test warning is logged for unrecognized MAILVIEW_ENABLED values."""
+        env = {"MAILVIEW_ENABLED": "enabled", "DEBUG": "1"}
+        with (
+            patch.dict(os.environ, env, clear=True),
+            caplog.at_level(logging.WARNING, logger="mailview"),
+        ):
+            result = is_mailview_enabled()
+            assert "not recognized" in caplog.text
+            assert "enabled" in caplog.text
+            # Should fall back to auto-detection (DEBUG=1 -> True)
+            assert result is True
+
+
+class TestIsProductionEnvironment:
+    """Tests for production environment detection."""
+
+    def test_environment_production(self):
+        """Test ENVIRONMENT=production is detected."""
+        with patch.dict(os.environ, {"ENVIRONMENT": "production"}, clear=True):
+            assert is_production_environment() is True
+
+    def test_environment_prod(self):
+        """Test ENVIRONMENT=prod is detected."""
+        with patch.dict(os.environ, {"ENVIRONMENT": "prod"}, clear=True):
+            assert is_production_environment() is True
+
+    def test_environment_staging(self):
+        """Test ENVIRONMENT=staging is detected as production-like."""
+        with patch.dict(os.environ, {"ENVIRONMENT": "staging"}, clear=True):
+            assert is_production_environment() is True
+
+    def test_env_production(self):
+        """Test ENV=production is detected."""
+        with patch.dict(os.environ, {"ENV": "production"}, clear=True):
+            assert is_production_environment() is True
+
+    def test_development_not_detected(self):
+        """Test development environment is not detected as production."""
+        with patch.dict(os.environ, {"ENVIRONMENT": "development"}, clear=True):
+            assert is_production_environment() is False
+
+    def test_no_env_vars(self):
+        """Test no env vars returns False."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert is_production_environment() is False
+
+    def test_case_insensitive(self):
+        """Test production detection is case-insensitive."""
+        with patch.dict(os.environ, {"ENVIRONMENT": "PRODUCTION"}, clear=True):
+            assert is_production_environment() is True

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -11,7 +11,7 @@ from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
-from mailview.middleware import MailviewMiddleware, is_dev_environment
+from mailview.middleware import MailviewMiddleware
 from mailview.models import Email
 
 
@@ -32,50 +32,6 @@ def create_app(middleware_kwargs=None):
     app = Starlette(routes=[Route("/", homepage)])
     kwargs = middleware_kwargs or {}
     return MailviewMiddleware(app, **kwargs)
-
-
-class TestIsDevEnvironment:
-    """Tests for dev environment detection."""
-
-    def test_debug_true(self):
-        """Test DEBUG=1 is detected."""
-        with patch.dict(os.environ, {"DEBUG": "1"}, clear=True):
-            assert is_dev_environment() is True
-
-    def test_debug_true_string(self):
-        """Test DEBUG=true is detected."""
-        with patch.dict(os.environ, {"DEBUG": "true"}, clear=True):
-            assert is_dev_environment() is True
-
-    def test_environment_development(self):
-        """Test ENVIRONMENT=development is detected."""
-        with patch.dict(os.environ, {"ENVIRONMENT": "development"}, clear=True):
-            assert is_dev_environment() is True
-
-    def test_env_dev(self):
-        """Test ENV=dev is detected."""
-        with patch.dict(os.environ, {"ENV": "dev"}, clear=True):
-            assert is_dev_environment() is True
-
-    def test_fastapi_env(self):
-        """Test FASTAPI_ENV=development is detected."""
-        with patch.dict(os.environ, {"FASTAPI_ENV": "development"}, clear=True):
-            assert is_dev_environment() is True
-
-    def test_flask_env(self):
-        """Test FLASK_ENV=development is detected."""
-        with patch.dict(os.environ, {"FLASK_ENV": "development"}, clear=True):
-            assert is_dev_environment() is True
-
-    def test_production_not_detected(self):
-        """Test production environment is not detected as dev."""
-        with patch.dict(os.environ, {"ENVIRONMENT": "production"}, clear=True):
-            assert is_dev_environment() is False
-
-    def test_no_env_vars(self):
-        """Test no env vars returns False."""
-        with patch.dict(os.environ, {}, clear=True):
-            assert is_dev_environment() is False
 
 
 class TestMiddlewareInit:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,49 @@
+"""Tests for URL path utilities."""
+
+import pytest
+
+from mailview.paths import normalize_mount_path
+
+
+class TestNormalizeMountPath:
+    """Tests for mount path normalization."""
+
+    def test_valid_path(self):
+        """Test valid path is returned unchanged."""
+        assert normalize_mount_path("/_mail") == "/_mail"
+
+    def test_strips_trailing_slash(self):
+        """Test trailing slash is stripped."""
+        assert normalize_mount_path("/_mail/") == "/_mail"
+
+    def test_adds_leading_slash(self):
+        """Test leading slash is added if missing."""
+        assert normalize_mount_path("_mail") == "/_mail"
+
+    def test_strips_whitespace(self):
+        """Test whitespace is stripped."""
+        assert normalize_mount_path("  /_mail  ") == "/_mail"
+
+    def test_empty_raises(self):
+        """Test empty path raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty"):
+            normalize_mount_path("")
+
+    def test_whitespace_only_raises(self):
+        """Test whitespace-only path raises ValueError."""
+        with pytest.raises(ValueError, match="non-empty"):
+            normalize_mount_path("   ")
+
+    def test_root_raises(self):
+        """Test root path raises ValueError."""
+        with pytest.raises(ValueError, match="non-root"):
+            normalize_mount_path("/")
+
+    def test_root_with_trailing_slash_raises(self):
+        """Test root with trailing slash raises ValueError."""
+        with pytest.raises(ValueError, match="non-root"):
+            normalize_mount_path("//")
+
+    def test_nested_path(self):
+        """Test nested paths work."""
+        assert normalize_mount_path("/api/mail") == "/api/mail"


### PR DESCRIPTION
## Summary

Adds dedicated environment detection module with safety checks to prevent mailview running in production.

- `mailview/env.py` with `is_dev_environment()` and `is_mailview_enabled()` functions
- `MAILVIEW_ENABLED=true` env var for explicit override (logs warning)
- `MAILVIEW_ENABLED=false` to force disable
- Falls back to auto-detection via DEBUG, ENVIRONMENT, ENV, FASTAPI_ENV, FLASK_ENV
- Moves env detection from middleware.py to dedicated module

### Activation Rules

1. `MAILVIEW_ENABLED=true` -> force enable (with warning)
2. `MAILVIEW_ENABLED=false` -> force disable
3. Otherwise, auto-detect via common dev environment indicators

## Test plan

- [x] Tests for is_dev_environment() with various env vars
- [x] Tests for is_mailview_enabled() with MAILVIEW_ENABLED override
- [x] Test warning is logged when force-enabled
- [x] Test no warning when auto-detected
- [x] Test case-insensitivity
- [x] All 134 tests passing
- [x] Linting and security checks passing

Closes #10