### PR TITLE
📸 Add UI screenshots to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ Navigate to `/_mail` to see:
 
 Clear all emails with the delete button or `DELETE /_mail/api/emails`.
 
+### Screenshots
+
+**Inbox List**
+![Inbox List](docs/screenshots/inbox-list.png)
+
+**Email Detail View**
+![Email Detail](docs/screenshots/email-detail.png)
+
+**Email Headers**
+![Email Headers](docs/screenshots/email-headers.png)
+
 ## Configuration
 
 Mailview works with zero configuration, but you can customise if needed:


### PR DESCRIPTION
## Summary

- Add screenshots section to Browser UI documentation
- Shows inbox list, email detail view, and headers tab

## Screenshots

The following screenshots are now included in the README:

- `docs/screenshots/inbox-list.png` - Email inbox with dark theme
- `docs/screenshots/email-detail.png` - HTML preview with detail panel
- `docs/screenshots/email-headers.png` - Headers tab view