### PR TITLE
🔧 Fix Codecov upload parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,11 @@ jobs:
         run: pytest --cov=mailview --cov-report=xml
 
       - name: Upload coverage
+        if: matrix.python-version == '3.11'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           fail_ci_if_error: false
 
   security:


### PR DESCRIPTION
## Summary
Fix Codecov badge showing "unknown" by correcting the upload parameter.

## Changes
- `file:` → `files:` (codecov-action v5 renamed this parameter)
- Only upload from Python 3.11 matrix job (avoids duplicate uploads)